### PR TITLE
Use irc.error() for error output

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -97,7 +97,7 @@ class WorldTime(callbacks.Plugin):
         # try and fetch url
         response = self._fetch(url)
         if not response:
-            irc.error("I could not fetch: {0}".format(url), Raise=True)
+            irc.error("I could not fetch: {0}".format(url))
             return None
         
         # wrap in a big try/except
@@ -123,7 +123,7 @@ class WorldTime(callbacks.Plugin):
         # try and fetch url
         response = self._fetch(url)
         if not response:
-            irc.error("I could not fetch: {0}".format(url), Raise=True)
+            irc.error("I could not fetch: {0}".format(url))
             return None
         
         # wrap in a big try/except


### PR DESCRIPTION
This is a more standard way to do things with Supybot, and plays nicer with i18n and configured message handling (`irc.error()` can be set to go into notice, etc.)
